### PR TITLE
Rename ocr parameter to ocr_enabled in Emunium class

### DIFF
--- a/emunium/_standalone/facade.py
+++ b/emunium/_standalone/facade.py
@@ -13,12 +13,12 @@ from emunium._standalone.config import ClickType, Config, StandaloneConfig
 class Emunium:
     def __init__(
         self,
-        ocr: bool = False,
+        ocr_enabled: bool = False,
         use_gpu: bool = True,
         langs: list[str] | None = None,
     ) -> None:
         self.cursor = SystemCursor()
-        self.ocr = ocr
+        self.ocr = ocr_enabled
         self.ocr_reader = None
         self.monitor_region: tuple[int, int, int, int] | None = None
 


### PR DESCRIPTION
This was causing an error when I was enabling ocr=True

`    self.ocr_reader = ocr.initialize_ocr(langs or ["en"], use_gpu)
                      ^^^^^^^^^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'initialize_ocr'
python-BaseException

Process finished with exit code 1
`

This change is not only a naming improvement, the previous parameter name shadowed the imported ocr module, causing ocr.initialize_ocr to resolve to True.initialize_ocr, which raises the reported AttributeError. Renaming the parameter prevents module shadowing and fixes the runtime bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The parameter for enabling OCR functionality has been renamed for improved clarity. Existing code will need to be updated with the new parameter name to continue using OCR features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->